### PR TITLE
Code reads references information from mutation list

### DIFF
--- a/mavisp/core.py
+++ b/mavisp/core.py
@@ -34,7 +34,6 @@ class MAVISpFileSystem:
     supported_stability_methods = ['foldx5', 'rosetta_ref2015', 'rosetta_cartddg2020_ref2015']
     supported_interaction_methods = ['foldx5']
     supported_modules = [ CancermutsTable,
-                          References,
                           PTMs,
                           LongRange,
                           Stability,

--- a/mavisp/core.py
+++ b/mavisp/core.py
@@ -90,8 +90,8 @@ class MAVISpFileSystem:
 
                 try:
                     mutation_list = self._parse_mutation_list(system, mode)
-                except:
-                    self.log.error(f"Couldn't parse mutation list table for {system}, {mode}")
+                except Exception as e:
+                    self.log.error(e)
                     mutation_list = None
 
                 try:
@@ -172,16 +172,14 @@ class MAVISpFileSystem:
         mut_path = os.path.join(self.data_dir, system, mode, 'mutation_list', most_recent_mut_file)
 
         try:
-            mutations = pd.read_csv(mut_path, sep='\t')
+            mutations = pd.read_csv(mut_path, delim_whitespace=True)
         except Exception as e:
-            self.log.error("Couldn't parse mutation list {mut_path}")
-            raise e
+            raise TypeError(f"Couldn't parse mutation list {mut_path} with error {e}")
 
         # remove duplicates, sort
         mutations = mutations.drop_duplicates(ignore_index=True)
         if len(mutations['mutation']) != mutations['mutation'].unique().shape[0]:
-            self.log.error("Duplicate mutations with inconsistent references in the mutation list")
-            raise TypeError
+            raise TypeError(f"{system}, {mode}: Duplicate mutations with inconsistent references in the mutation list")
 
         mutations['res_num'] = mutations['mutation'].str[1:-1].astype(int)
         mutations['alt'] = mutations['mutation'].str[-1]

--- a/mavisp/mavisp.py
+++ b/mavisp/mavisp.py
@@ -56,7 +56,7 @@ legend = f"""legend:
 {colored("    ~ module_name", 'yellow')}    warnings detected in this module, with no errors
     = module_name    this module is not available for this protein"""
 
-module_order = ['stability', 'local_interactions', 'local_interactions_DNA', 'sas', 'cancermuts', 'references', 'ptms', 'long_range', 'clinvar', 'alphafold', 'demask', 'gemme']
+module_order = ['stability', 'local_interactions', 'local_interactions_DNA', 'sas', 'cancermuts', 'ptms', 'long_range', 'clinvar', 'alphafold', 'demask', 'gemme']
 
 def main():
 

--- a/mavisp/mavisp.py
+++ b/mavisp/mavisp.py
@@ -252,7 +252,6 @@ def main():
             this_df = this_df.join(mod.get_dataset_view())
 
         # move Reference column to last
-        print(this_df.columns)
         this_df = this_df[[c for c in this_df.columns if c != 'References'] + ['References']]
 
         # fill NAs

--- a/mavisp/mavisp.py
+++ b/mavisp/mavisp.py
@@ -240,7 +240,9 @@ def main():
         if len(r['criticals']) > 0:
             continue
 
-        this_df = pd.DataFrame({'Mutation': r['mutations']})
+        this_df = r['mutations']
+        this_df = this_df.rename(columns={'mutation' : 'Mutation',
+                                          'PMID'     : 'References'})
         this_df = this_df.set_index('Mutation')
 
         for mod_name in module_order:
@@ -249,5 +251,12 @@ def main():
                 continue
             this_df = this_df.join(mod.get_dataset_view())
 
+        # move Reference column to last
+        print(this_df.columns)
+        this_df = this_df[[c for c in this_df.columns if c != 'References'] + ['References']]
+
+        # fill NAs
         this_df = this_df.fillna(pd.NA)
+
+        # save final dataframe
         this_df.to_csv(dataset_tables_path / f"{r['system']}-{r['mode']}.csv")

--- a/mavisp/modules.py
+++ b/mavisp/modules.py
@@ -339,48 +339,6 @@ class LongRange(MultiMethodDataType):
     name = "long_range"
     methods = {'allosigma2' : AlloSigma(version=2)}
 
-class References(DataType):
-
-    module_dir = "pmid_list"
-    name = "references"
-
-    def ingest(self, mutations):
-        warnings = []
-
-        pmid_files = os.listdir(os.path.join(self.data_dir, self.module_dir))
-        if len(pmid_files) != 1:
-            this_error = f"multiple or no files found in {pmid_files}; only one expected"
-            raise MAVISpMultipleError(warning=warnings,
-                                      critical=[MAVISpCriticalError(this_error)])
-
-        pmid_file = pmid_files[0]
-
-        log.info(f"parsing PMID file {pmid_file}")
-
-        try:
-            pmid = pd.read_csv(os.path.join(self.data_dir, self.module_dir, pmid_file), delim_whitespace=True)
-        except Exception as e:
-            this_error = f"Exception {type(e).__name__} occurred when parsing the csv files. Arguments:{e.args}"
-            raise MAVISpMultipleError(warning=warnings,
-                                      critical=[MAVISpCriticalError(this_error)])
-
-        if 'mutation' not in pmid.columns or 'PMID' not in pmid.columns:
-            this_error = f"The CSV file must contain the following columns: mutation, PMID"
-            raise MAVISpMultipleError(warning=warnings,
-                                      critical=[MAVISpCriticalError(this_error)])
-
-        if len(pmid.columns) != 2:
-            warnings.append(MAVISpWarningError("The CSV file has more than two columns"))
-
-        pmid = pmid[['mutation', 'PMID']]
-        pmid = pmid.set_index('mutation')
-        pmid = pmid[~ pmid.index.duplicated(keep='first')]
-        self.data = pmid.rename(columns={'PMID':'PMID / DOI'})
-
-        if len(warnings) > 0:
-            raise MAVISpMultipleError(warning=warnings,
-                                      critical=[])
-
 class SAS(DataType):
 
     module_dir = "sas"


### PR DESCRIPTION
fixes #122 #119

This PR moves the parsing of references information from the References module to main code, so that references are read directly from the mutation list. The mutation list now needs to be in the format of the old References module input file, so two (`\s+`)-separated columns (`Mutation` and `PMID`). This file now needs to be located in the `mutation_list` folder. Changes include:

* removal of `References` module
* internal changes to core to support the new format
* better checks on mutation redundancies
* rename of the column in the dataset files for PMID, now called `References` (hence fixing #119) 