### PR TITLE
Remove pkg_resources runtime dependency

### DIFF
--- a/mavisp/modules.py
+++ b/mavisp/modules.py
@@ -21,13 +21,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from importlib.resources import as_file, files
 import pandas as pd
 from mavisp.methods import *
 from mavisp.utils import three_to_one, three_to_one_hgvsp
 from collections import defaultdict
 import logging as log
 import re
-import pkg_resources
 import numbers
 import yaml
 
@@ -1444,8 +1444,8 @@ class PTMs(MavispModule):
                                       critical=[MAVISpCriticalError(this_error)])
 
         # load phospho-SLiM data file
-        fname = pkg_resources.resource_filename(__name__, 'data/phosphoSLiMs_15062023.csv')
-        phospho_slims = pd.read_csv(fname)
+        with as_file(files(__package__).joinpath('data/phosphoSLiMs_15062023.csv')) as fname:
+            phospho_slims = pd.read_csv(fname)
 
         # create final table
         final_table = pd.DataFrame({'mutation' : mutations})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "pyyaml",
     "requests",
     "termcolor",
-    "setuptools",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

- replace `pkg_resources.resource_filename()` with `importlib.resources` when
  reading the packaged phospho-SLiM data file
- remove the runtime `setuptools` dependency that was only needed for
  `pkg_resources`, while retaining setuptools as the build backend

## Rationale

`mavisp/modules.py` currently imports `pkg_resources` while loading packaged
data. Recent setuptools installations no longer provide that module, which
prevents the MAVISp package from being used in those environments. The package
already requires Python 3.12 or newer, so the standard-library resource API can
provide the same packaged-file access without a setuptools runtime dependency.

Fixes #392

## Validation

- `git diff --check HEAD~1..HEAD`
- static search for remaining `pkg_resources` references in `mavisp` and
  `pyproject.toml`
- Not run locally
